### PR TITLE
Claytonm/grfn3

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,7 +20,7 @@ help:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 
-${SOURCEDIR}/air_openapi.html: 
+${SOURCEDIR}/air_openapi.html:
 	python3 swagger-yaml-to-html.py ${SOURCEDIR}/air_openapi.yaml $@
 
 ${SOURCEDIR}/cast_openapi_v1.0.0.html:
@@ -32,9 +32,12 @@ ${SOURCEDIR}/cast_openapi_v1.0.0.html:
 ${SOURCEDIR}/grfn_openapi_v2.1.0.html:
 	python3 swagger-yaml-to-html.py ${SOURCEDIR}/grfn_openapi_v2.1.0.yaml $@
 
+${SOURCEDIR}/grfn_openapi_v2.2.0.html:
+	python3 swagger-yaml-to-html.py ${SOURCEDIR}/grfn_openapi_v2.2.0.yaml $@
+
 ${SOURCEDIR}/grfn_openapi_v3.0.0.html:
 	python3 swagger-yaml-to-html.py ${SOURCEDIR}/grfn_openapi_v3.0.0.yaml $@
 
-apidocs: ${SOURCEDIR}/air_openapi.html ${SOURCEDIR}/cast_openapi_v1.0.0.html ${SOURCEDIR}/grfn_openapi_v2.1.0.html ${SOURCEDIR}/grfn_openapi_v3.0.0.html
+apidocs: ${SOURCEDIR}/air_openapi.html ${SOURCEDIR}/cast_openapi_v1.0.0.html ${SOURCEDIR}/grfn_openapi_v2.2.0.html ${SOURCEDIR}/grfn_openapi_v3.0.0.html
 	rm -rf generated/
 	sphinx-apidoc -o source ../src -f

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -38,6 +38,9 @@ ${SOURCEDIR}/grfn_openapi_v2.2.0.html:
 ${SOURCEDIR}/grfn_openapi_v3.0.0.html:
 	python3 swagger-yaml-to-html.py ${SOURCEDIR}/grfn_openapi_v3.0.0.yaml $@
 
-apidocs: ${SOURCEDIR}/air_openapi.html ${SOURCEDIR}/cast_openapi_v1.0.0.html ${SOURCEDIR}/grfn_openapi_v2.2.0.html ${SOURCEDIR}/grfn_openapi_v3.0.0.html
+${SOURCEDIR}/grfn_openapi_v3.0.0.html:
+	python3 swagger-yaml-to-html.py ${SOURCEDIR}/grfn_openapi_metadata.yaml $@
+
+apidocs: ${SOURCEDIR}/air_openapi.html ${SOURCEDIR}/cast_openapi_v1.0.0.html ${SOURCEDIR}/grfn_openapi_v2.2.0.html ${SOURCEDIR}/grfn_openapi_v3.0.0.html ${SOURCEDIR}/grfn_openapi_metadata.yaml
 	rm -rf generated/
 	sphinx-apidoc -o source ../src -f

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -38,9 +38,9 @@ ${SOURCEDIR}/grfn_openapi_v2.2.0.html:
 ${SOURCEDIR}/grfn_openapi_v3.0.0.html:
 	python3 swagger-yaml-to-html.py ${SOURCEDIR}/grfn_openapi_v3.0.0.yaml $@
 
-${SOURCEDIR}/grfn_openapi_v3.0.0.html:
+${SOURCEDIR}/grfn_openapi_metadata.html:
 	python3 swagger-yaml-to-html.py ${SOURCEDIR}/grfn_openapi_metadata.yaml $@
 
-apidocs: ${SOURCEDIR}/air_openapi.html ${SOURCEDIR}/cast_openapi_v1.0.0.html ${SOURCEDIR}/grfn_openapi_v2.2.0.html ${SOURCEDIR}/grfn_openapi_v3.0.0.html ${SOURCEDIR}/grfn_openapi_metadata.yaml
+apidocs: ${SOURCEDIR}/air_openapi.html ${SOURCEDIR}/cast_openapi_v1.0.0.html ${SOURCEDIR}/grfn_openapi_v2.2.0.html ${SOURCEDIR}/grfn_openapi_v3.0.0.html ${SOURCEDIR}/grfn_openapi_metadata.html
 	rm -rf generated/
 	sphinx-apidoc -o source ../src -f

--- a/docs/source/grfn_openapi_metadata.rst
+++ b/docs/source/grfn_openapi_metadata.rst
@@ -1,0 +1,5 @@
+GrFN JSON OpenAPI Metadata Spec - v1.0.0
+========================================
+
+.. raw:: html
+  :file: grfn_openapi_metadata.html

--- a/docs/source/grfn_openapi_metadata.yaml
+++ b/docs/source/grfn_openapi_metadata.yaml
@@ -1,0 +1,236 @@
+openapi: 3.0.0
+
+info:
+  title: GrFN JSON Metadata spec
+  description: >
+    AutoMATES Grounded Function Network (GrFN) JSON Metadata schema specification
+  contact:
+    name: Clayton T. Morrison
+    email: claytonm@arizona.edu
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+  version: 1.0.0
+
+paths: {}
+
+components:
+
+  schemas:
+
+    ### metadata
+
+    metadata:
+      title: <metadata>
+      description: >
+        Typed metadata consisting of an array of attribute-value pairs.
+        \<grfn> is grounded through metadata.
+      required:
+        - type
+        - attributes
+      properties:
+        type:
+          description: Type of metadata.
+          type: string
+        provenance:
+          $ref: '#/components/schemas/provenance'
+        # attributes:
+        #   description: Array of \<attribute> attribute-value pairs.
+        #   type: array
+        #   items:
+        #     $ref: '#/components/schemas/attribute'
+
+    provenance:
+      title: <provenance>
+      description: Provenance of metadata.
+      required:
+        - method
+        - date_time
+      properties:
+        method:
+          description: >
+            The (top-level) inference method (with version) used to derive data.
+          type: string
+        date_time:
+          description: >
+            Date and time that metadata was generated.
+          type: string
+          format: date-time
+        sources:
+          description: >
+            Array of sources.
+            (TODO: add additional source types)
+          type: array
+          items:
+            $ref: '#/components/schemas/text_document_source_ref'
+
+    attribute:
+      title: <attribute>
+      description: An attribute-value pair.
+      required:
+        - name
+        - value
+      properties:
+        type:
+          default: "attribute"
+        name:
+          description: The name of the attribute.
+          type: string
+        value:
+          description: The value of the attribute.
+          type: string
+
+    ### Provenenace source types
+
+    text_document_source_ref:
+      title: <text_document_source_ref>
+      description: Provenance object representing document source information.
+      required:
+        - source_type
+        - document_reference_uid
+        - text_location
+      properties:
+        source_type:
+          type: string
+          default: "text_document_source"
+        document_reference_uid:
+          description: uid of \<document_reference>
+          type: string
+        text_location:
+          $ref: '#/components/schemas/text_location'
+
+    text_location:
+      title: <text_location>
+      description: Coordinates of text spans
+      properties:
+        spans:
+          type: array
+          items:
+            $ref: '#/components/schemas/text_span_ref'
+
+    text_span_ref:
+      title: <text_span_ref>
+      description: Reference coordinates to a span of text
+      required:
+        - page
+        - block
+        - span
+      properties:
+        page:
+          type: integer
+        block:
+          type: integer
+        span:
+          $ref: '#/components/schemas/text_span'
+
+    text_span:
+      title: <text_span>
+      description: Span of text
+      required:
+        - char_begin
+        - char_end
+      properties:
+        char_begin:
+          description: Character coordinate within a text block where span begins
+          type: integer
+        char_end:
+          description: Character coordinate within a text block where span ends
+          type: integer
+
+    ### <grfn>
+
+    textual_document_reference:
+      allOf:
+        - $ref: '#/components/schemas/metadata'
+      title: <grfn>.<textual_document_reference>
+      description: >
+        host: \<grfn> <br>
+        A reference to a textual document (e.g., documentation, scientific publication, etc.).
+      required:
+        - documents
+      properties:
+        type:
+          default: "textual_document_reference"
+        documents:
+          description: List of document references
+          type: array
+          items:
+            $ref: '#/components/schemas/document_reference'
+
+    document_reference:
+      title: <document_reference>
+      description: Document reference.
+      required:
+        - uid
+        - global_reference_id
+      properties:
+        cosmos_id:
+          description: TODO
+          type: string
+        cosmos_version_number:
+          description: TODO
+          type: string
+        automates_id:
+          description: TODO
+          type: string
+        automates_version_number:
+          description: TODO
+          type: string
+
+    ### <variable> | <function>
+
+    text-definition:
+      allOf:
+        - $ref: '#/components/schemas/metadata'
+      title: <variable,function>.<text-definition>
+      description: >
+        host: { \<variable>, \<function> } <br>
+        Definition of host derived from a text source.<br>
+        Example: "attributes": { "text_identifier": "γ", "text_definition": "gamma" }
+      required:
+        - attributes
+      properties:
+        type:
+          default: "text-definition"
+        attributes:
+          description: Array of \<attribute> attribute-value pairs.
+          type: array
+          items:
+            $ref: '#/components/schemas/attribute'
+
+    ### <variable>
+
+    measurement_scale:
+      allOf:
+        - $ref: '#/components/schemas/metadata'
+      title: <variable>.<measurement_scale>
+      description: >
+        host: \<variable> <br>
+        The measurement scale of \<variable> value.<br>
+      required:
+        - measurement_scale
+      properties:
+        type:
+          default: "measurement_scale"
+        measurement_scale:
+          description: >
+            Values: \"binary\", \"categorical\", \"continuous\"
+          type: string
+          enum: [ BINARY, categorical, continuous ]
+
+    value_domain:
+      allOf:
+        - $ref: '#/components/schemas/metadata'
+      title: <variable>.<value_domain>
+      description: >
+        host: \<variable> <br>
+        Expression of the possible values data can take, as interval.<br>
+      required:
+        - value_domain
+      properties:
+        type:
+          default: "value_domain"
+        value_domain:
+          description: >
+            Example\: \"(and (> v -infty) (< v infty))\"
+          type: string

--- a/docs/source/grfn_openapi_v2.2.0.rst
+++ b/docs/source/grfn_openapi_v2.2.0.rst
@@ -1,0 +1,5 @@
+GrFN JSON OpenAPI Spec - v2.2.0
+===============================
+
+.. raw:: html
+  :file: grfn_openapi_v2.2.0.html

--- a/docs/source/grfn_openapi_v2.2.0.yaml
+++ b/docs/source/grfn_openapi_v2.2.0.yaml
@@ -1,0 +1,320 @@
+openapi: 3.0.0
+
+info:
+  title: GrFN spec
+  description: Grounded Function Network (GrFN) schema specification
+  contact:
+    name: Clayton T. Morrison
+    email: claytonm@email.arizona.edu
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+  version: 2.2.0
+
+paths: {}
+
+components:
+
+  schemas:
+
+    grfn:
+      title: <grfn>
+      description: >
+        Top-level structure.
+        A <grfn_def> corresponds to a namespace.
+      required:
+        - uid
+        - date_created
+        - functions
+        - variables
+        - edges
+        - containers
+      properties:
+        uid:
+          description: GrFN unique identifier
+          type: string
+        date_created:
+          description: >
+            Date and time that current GrFN was generated.
+          type: string
+          format: date-time
+        variables:
+          type: array
+          items:
+            $ref: '#/components/schemas/variable'
+        functions:
+          type: array
+          items:
+            $ref: '#/components/schemas/function'
+        hyper_edges:
+          type: array
+          items:
+            $ref: '#/components/schemas/hyper_edge'
+        subgraphs:
+          type: array
+          items:
+            $ref: '#/components/schemas/subgraph'
+        # metadata
+        metadata:
+          description: Metadata associated with \<grfn>.
+          type: array
+          items:
+            $ref: '#/components/schemas/metadata'
+
+    hyper_edge:
+      title: <hyper_edge>
+      description: GrFN hyper_edge
+      required:
+      - inputs
+      - function
+      - outputs
+      properties:
+        inputs:
+          type: array
+          items:
+            $ref: '#/components/schemas/variable'
+        function:
+          $ref: '#/components/schemas/function'
+        outputs:
+          type: array
+          items:
+            $ref: '#/components/schemas/variable'
+
+    variable:
+      title: <variable>
+      description: A representation of a variable extracted from source code
+      required:
+        - identifier
+        - uid
+        - reference
+      properties:
+        identifier:
+          description: (name) Variable basename and index extracted from source code
+          type: string
+        uid:
+          description: Variable unique identifier
+          type: string
+        type:
+          description: float32, float64, integer, string, boolean
+          type: string
+        kind:
+          description: (measurement_scale) The measurement scale of this data-type binary/categorical/discrete/continuous
+          type: string
+        domain:
+          description: >
+            Expression of the possible values data can take, as interval
+            \"(and (> v -infty) (< v infty))\"
+          type: string
+        reference:
+          description: Grounding reference to scientific variable ontology
+          type: string
+        # metadata
+        metadata:
+          description: Metadata associated with \<variable>.
+          type: array
+          items:
+            $ref: '#/components/schemas/metadata'
+
+    function:
+      title: <function>
+      description: A representation of a functional computation extracted from source code
+      required:
+        - uid
+        - type
+        - reference
+        - lambda
+      properties:
+        uid:
+          description: Function unique identifier
+          type: string
+        type: # pass, literal, assignment, condition, decision
+          description: >
+            States the type of function being computed by this function node<br>
+            <em>function interface</em> \"INTERFACE\" <br>
+            <em>compound object reference</em>: [ \"EXTRACT\", \"PACK\" ] <br>
+            <em>executable + instances (wiring)</em>: [ \"LITERAL\", \"ASSIGN\", \"CONDITION\", \"DECISION\" ]
+          type: string
+        reference:
+          description: Grounding reference to scientific variable ontology
+          type: string
+        lambda:
+          description: Stringified pythonic version of the lambda function code
+          type: string
+        # metadata
+        metadata:
+          description: Metadata associated with \<grfn>.
+          type: array
+          items:
+            $ref: '#/components/schemas/metadata'
+
+    subgraph:
+      title: <subgraph>
+      description: >
+        TODO
+      required:
+        - uid
+        - basename
+        - nodes
+      properties:
+        uid:
+          description: Subgraph unique identifier
+          type: string
+        namespace:
+          description: The namespace path of the subgraph
+          type: string
+        scope:
+          description: The scope path of the subgraph
+          type: string
+        basename:
+          description: >
+            A reference to the container that shows the original module path, scope path, and container name
+          type: string
+        occurrence_num:
+          description: The subgraph instance tag
+          type: string
+        parent:
+          description: the container uid for the parent container to this container
+          type: string
+        type:
+          description: >
+            \"FuncContainer\", \"CondContainer\", \"LoopContainer\"
+          type: string
+        exit:
+          description: >
+            A function unique identifier for the lambda function that computes the exit condition
+          type: string
+        nodes:
+          description: >
+            Array of uids referring to variables and functions in the subgraph
+          type: array
+          items:
+            type: string
+        # metadata
+        metadata:
+          description: Metadata associated with \<grfn>.
+          type: array
+          items:
+            $ref: '#/components/schemas/metadata'
+
+    ### user-defined types
+
+    composite_type:
+      title: <composite_type>
+      description: TODO
+      required:
+        - id
+        # - built_in
+        - name
+      properties:
+        id:
+          description: Unique identifier.
+          type: string
+        # built_in:
+        #   description: TODO
+        #   type: boolean
+        name::
+          description: Name of the data type
+          type: string
+        fields:
+          description: >
+            Array of field-name (string) paired with optional type-name (string).
+            When no type specified, the type-name is empty-string.
+          type: array
+          items:
+            $ref: '#/components/schemas/attribute'
+        metadata:
+          description: Metadata associated with the \<type> declaration.
+          type: array
+          items:
+            $ref: '#/components/schemas/metadata'
+
+    object:
+      title: <object>
+      description: >
+        An object an instance of a \<type> where fields are instantiated
+        as persistent storage with associated values.
+        Each field is represented by a variable.
+      properties:
+        id:
+          description: Unique identifier.
+          type: string
+        type:
+          description: TODO
+          type: string
+        instance_ids:
+          description: >
+            Array of field instance_ids
+          type: array
+          items:
+            type: string
+        field_instances:
+          description: >
+            Array of pairs of \<field_operation>: \<field instance_id>, \<operation_spec>
+          type: array
+          items:
+            $ref: '#/components/schemas/attribute'
+        metadata:
+          type: array
+          description: Metadata associated with the \<object> instance.
+          items:
+            $ref: '#/components/schemas/metadata'
+
+    ### metadata
+
+    metadata:
+      title: <metadata>
+      description: >
+        Typed metadata consisting of an array of attribute-value pairs.
+        \<grfn> is grounded through metadata.
+      required:
+        - type
+        - attributes
+      properties:
+        type:
+          description: Type of metadata.
+          type: string
+        provenance:
+          description: Provenance of metadata.
+          $ref: '#/components/schemas/provenance'
+        attributes:
+          description: Array of \<attribute> attribute-value pairs.
+          type: array
+          items:
+            $ref: '#/components/schemas/attribute'
+
+    provenance:
+      title: <provenance>
+      description: Provenance of data.
+      required:
+        - method
+        - date_time
+      properties:
+        method:
+          description: >
+            The (top-level) inference method (with version) used to derive data.
+          type: string
+        date_time:
+          description: >
+            Date and time that current GrFN was generated.
+          type: string
+          format: date-time
+        source:
+          description: >
+            Array of attributes pairing source type (name) with source identifier (value).
+          type: array
+          items:
+            $ref: '#/components/schemas/attribute'
+
+    attribute:
+      title: <attribute>
+      description: An attribute-value pair.
+      required:
+        - name
+        - value
+      properties:
+        name:
+          description: The name of the attribute.
+          type: string
+        value:
+          description: The value of the attribute.
+          type: string

--- a/docs/source/grfn_openapi_v2.2.0.yaml
+++ b/docs/source/grfn_openapi_v2.2.0.yaml
@@ -38,6 +38,14 @@ components:
             Date and time that current GrFN was generated.
           type: string
           format: date-time
+        types:
+          type: array
+          items:
+            $ref: '#/components/schemas/type'
+        objects:
+          type: array
+          items:
+            $ref: '#/components/schemas/object'
         variables:
           type: array
           items:
@@ -80,6 +88,82 @@ components:
           items:
             $ref: '#/components/schemas/variable'
 
+    ### user-defined types
+
+    type:
+      title: <type>
+      description: Base type
+      required:
+        - uid
+        - name
+        - metatype
+      properties:
+        uid:
+          description: Unique identifier.
+          type: string
+        name:
+          description: Name of the data type
+          type: string
+        metatype:
+          description: Metatype of type.
+          type: string
+        metadata:
+          description: Metadata associated with the \<type> declaration.
+          type: array
+          items:
+            $ref: '#/components/schemas/metadata'
+
+    type_composite:
+      allOf:
+        - $ref: '#/components/schemas/type'
+      title: <type_composite>
+      description: A structured type with named field attributes.
+      required:
+        - fields
+      properties:
+        metatype:
+          type: string
+          default: "type_composite"
+        fields:
+          description: Array of named fields.
+          type: array
+          items:
+            $ref: '#/components/schemas/named_field'
+
+    named_field:
+      title: <named_field>
+      description: >
+        A named field, pairing the field name (string) with [optional]
+        field value type name (string).
+        When no type specified, the type name is null.
+      required:
+        - name
+        - type
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+
+    object:
+      title: <object>
+      description: >
+        An object an instance of a \<type> where fields are instantiated
+        as persistent storage with associated values.
+        Each field is represented by a variable.
+      properties:
+        uid:
+          description: Unique identifier object.
+          type: string
+        type:
+          description: uid of <object>'s <type>
+          type: string
+        metadata:
+          type: array
+          description: Metadata associated with the \<object> instance.
+          items:
+            $ref: '#/components/schemas/metadata'
+
     variable:
       title: <variable>
       description: A representation of a variable extracted from source code
@@ -94,20 +178,28 @@ components:
         uid:
           description: Variable unique identifier
           type: string
-        type:
-          description: float32, float64, integer, string, boolean
+        object_ref:
+          description: uid of host object (if applicable)
           type: string
-        kind:
-          description: (measurement_scale) The measurement scale of this data-type binary/categorical/discrete/continuous
-          type: string
-        domain:
+        data_type:
           description: >
-            Expression of the possible values data can take, as interval
-            \"(and (> v -infty) (< v infty))\"
+            float, float32, float64, integer, string, boolean, etc.<br>
+            TODO: Define GrFN execution model
           type: string
-        reference:
-          description: Grounding reference to scientific variable ontology
-          type: string
+
+        # The following are moved to metadata
+        # kind:
+        #   description: (measurement_scale) The measurement scale of this data-type binary/categorical/discrete/continuous
+        #   type: string
+        # domain:
+        #   description: >
+        #     Expression of the possible values data can take, as interval
+        #     \"(and (> v -infty) (< v infty))\"
+        #   type: string
+        # reference:
+        #   description: Grounding reference to scientific variable ontology
+        #   type: string
+
         # metadata
         metadata:
           description: Metadata associated with \<variable>.
@@ -196,125 +288,11 @@ components:
           items:
             $ref: '#/components/schemas/metadata'
 
-    ### user-defined types
-
-    composite_type:
-      title: <composite_type>
-      description: TODO
-      required:
-        - id
-        # - built_in
-        - name
-      properties:
-        id:
-          description: Unique identifier.
-          type: string
-        # built_in:
-        #   description: TODO
-        #   type: boolean
-        name::
-          description: Name of the data type
-          type: string
-        fields:
-          description: >
-            Array of field-name (string) paired with optional type-name (string).
-            When no type specified, the type-name is empty-string.
-          type: array
-          items:
-            $ref: '#/components/schemas/attribute'
-        metadata:
-          description: Metadata associated with the \<type> declaration.
-          type: array
-          items:
-            $ref: '#/components/schemas/metadata'
-
-    object:
-      title: <object>
-      description: >
-        An object an instance of a \<type> where fields are instantiated
-        as persistent storage with associated values.
-        Each field is represented by a variable.
-      properties:
-        id:
-          description: Unique identifier.
-          type: string
-        type:
-          description: TODO
-          type: string
-        instance_ids:
-          description: >
-            Array of field instance_ids
-          type: array
-          items:
-            type: string
-        field_instances:
-          description: >
-            Array of pairs of \<field_operation>: \<field instance_id>, \<operation_spec>
-          type: array
-          items:
-            $ref: '#/components/schemas/attribute'
-        metadata:
-          type: array
-          description: Metadata associated with the \<object> instance.
-          items:
-            $ref: '#/components/schemas/metadata'
-
     ### metadata
 
     metadata:
       title: <metadata>
       description: >
         Typed metadata consisting of an array of attribute-value pairs.
-        \<grfn> is grounded through metadata.
-      required:
-        - type
-        - attributes
-      properties:
-        type:
-          description: Type of metadata.
-          type: string
-        provenance:
-          description: Provenance of metadata.
-          $ref: '#/components/schemas/provenance'
-        attributes:
-          description: Array of \<attribute> attribute-value pairs.
-          type: array
-          items:
-            $ref: '#/components/schemas/attribute'
-
-    provenance:
-      title: <provenance>
-      description: Provenance of data.
-      required:
-        - method
-        - date_time
-      properties:
-        method:
-          description: >
-            The (top-level) inference method (with version) used to derive data.
-          type: string
-        date_time:
-          description: >
-            Date and time that current GrFN was generated.
-          type: string
-          format: date-time
-        source:
-          description: >
-            Array of attributes pairing source type (name) with source identifier (value).
-          type: array
-          items:
-            $ref: '#/components/schemas/attribute'
-
-    attribute:
-      title: <attribute>
-      description: An attribute-value pair.
-      required:
-        - name
-        - value
-      properties:
-        name:
-          description: The name of the attribute.
-          type: string
-        value:
-          description: The value of the attribute.
-          type: string
+        \<grfn> is grounded through metadata.<br>
+        See grfn_openapi_metadata

--- a/docs/source/grfn_openapi_v3.0.0.yaml
+++ b/docs/source/grfn_openapi_v3.0.0.yaml
@@ -175,8 +175,69 @@ components:
         out_variable_ids:
           description: Array of instance_ids for all output \<variable>s
           type: array
-          items: # variable_instance_id's
+          items:
             type: string
+
+    composite_type:
+      title: <composite_type>
+      description: TODO
+      required:
+        - id
+        # - built_in
+        - name
+      properties:
+        id:
+          description: Unique identifier.
+          type: string
+        # built_in:
+        #   description: TODO
+        #   type: boolean
+        name::
+          description: Name of the data type
+          type: string
+        fields:
+          description: >
+            Array of field-name (string) paired with optional type-name (string).
+            When no type specified, the type-name is empty-string.
+          type: array
+          items:
+            $ref: '#/components/schemas/attribute'
+        metadata:
+          description: Metadata associated with the \<type> declaration.
+          type: array
+          items:
+            $ref: '#/components/schemas/metadata'
+
+    object:
+      title: <object>
+      description: >
+        An object an instance of a \<type> where fields are instantiated
+        as persistent storage with associated values.
+        Each field is represented by a variable.
+      properties:
+        id:
+          description: Unique identifier.
+          type: string
+        type:
+          description: TODO
+          type: string
+        instance_ids:
+          description: >
+            Array of field instance_ids
+          type: array
+          items:
+            type: string
+        field_instances:
+          description: >
+            Array of pairs of \<field_operation>: \<field instance_id>, \<operation_spec>
+          type: array
+          items:
+            $ref: '#/components/schemas/attribute'
+        metadata:
+          type: array
+          description: Metadata associated with the \<object> instance.
+          items:
+            $ref: '#/components/schemas/metadata'
 
     instance:
       title: <instance>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,8 +14,7 @@ Welcome to AutoMATES's documentation!
    cast_openapi_v1.0.0
    grfn_openapi_v2.2.0
    grfn_openapi_v3.0.0
-   sample
-   modules
+   grfn_openapi_metadata
 
 
 Indices and tables

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@ Welcome to AutoMATES's documentation!
 
    air_openapi
    cast_openapi_v1.0.0
-   grfn_openapi_v2.1.0
+   grfn_openapi_v2.2.0
    grfn_openapi_v3.0.0
    sample
    modules


### PR DESCRIPTION
Implements the following changes:
- Replaces GrFN v2.1.0 with v2.2.0
- v2.2.0 changes from v2.1.0
  - \<type>
  - <type_composite>
  - \<object>
  - removes some \<variable> attributes to instead be represented as \<metadata>
- Adds GrFN_openapi_metadata v.1.0.0
  - First pass at capturing set of \<metadata> types