### PR TITLE
Uppercase Bibjson

### DIFF
--- a/docs/source/gromet_metadata_v0.1.5.yaml
+++ b/docs/source/gromet_metadata_v0.1.5.yaml
@@ -470,9 +470,9 @@ components:
           type: string
         bibjson:
           description: The bibjson entry for this document.<br>
-          $ref: '#/components/schemas/bibjson'
+          $ref: '#/components/schemas/Bibjson'
 
-    bibjson:
+    Bibjson:
       # title: <bibjson>
       description: See http://okfnlabs.org/bibjson/
 


### PR DESCRIPTION
This is probably not technically wrong, but code generators are not liking bibjson as a component.  If we allow ourselves to be assimilated, life will be easier.